### PR TITLE
Fix no_std compatibility and update to nalgebra 0.32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         rust: [stable]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        features: [--features default, --no-default-features]
+        features: [--features default, --no-default-features --feature no_std]
         include:
           - {rust: nightly, os: ubuntu-latest, features: --features default}
-          - {rust: nightly, os: ubuntu-latest, features: --no-default-features}
+          - {rust: nightly, os: ubuntu-latest, features: --no-default-features --feature no_std}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         rust: [stable]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        features: [--features default, --no-default-features --feature no_std]
+        features: [--features default, --no-default-features --features no_std]
         include:
           - {rust: nightly, os: ubuntu-latest, features: --features default}
-          - {rust: nightly, os: ubuntu-latest, features: --no-default-features --feature no_std}
+          - {rust: nightly, os: ubuntu-latest, features: --no-default-features --features no_std}
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cov-symmetric = []
 cov-joseph = []
 # Use Rust 'std', disable and enable 'no_std' to use in no_std enviroment
 std = ["nalgebra/std"]
-# Enable to use in no_srd enviroment
+# Enable to use in no_std environment
 no_std = ["nalgebra/libm", "dep:num-traits"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eskf"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jørgen Nordmoen <jorgen@nordmoen.net>"]
 description = "Navigation filter based on an Error State Kalman Filter (ESKF)"
 keywords = ["navigation", "filter", "orientation", "kalman"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,20 @@ full-reset = []
 cov-symmetric = []
 # Stable, symmetric and positive covariance update, computationally expensive
 cov-joseph = []
-# Use Rust 'std', disable to enable 'no_std'
+# Use Rust 'std', disable and enable 'no_std' to use in no_std enviroment
 std = ["nalgebra/std"]
+# Enable to use in no_srd enviroment
+no_std = ["nalgebra/libm", "dep:num-traits"]
 
 [dependencies]
-nalgebra = "0.29"
+nalgebra = { version = "0.32.3", default-features = false }
+num-traits = { version = "0.2.17", optional = true, default-features = false, features = [
+    "libm",
+] }
 
 [dev-dependencies]
 approx = "0.5.0"
-nalgebra = { version = "0.29", features = ["serde-serialize", "debug"] }
+nalgebra = { version = "0.32", features = ["serde-serialize", "debug"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 plotly = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,12 @@ use nalgebra::{
 #[cfg(feature = "no_std")]
 use num_traits::float::Float;
 
+#[cfg(any(
+    all(feature = "std", feature = "no_std"),
+    not(any(feature = "std", feature = "no_std"))
+))]
+compile_error!("Exactly one of features `std` and `no_std` must be enabled");
+
 /// Potential errors raised during operations
 #[derive(Copy, Clone, Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ use nalgebra::{
     base::allocator::Allocator, DefaultAllocator, Dim, Matrix2, Matrix3, OMatrix, OVector, Point3,
     UnitQuaternion, Vector2, Vector3, U1, U18, U2, U3, U5,
 };
+#[cfg(feature = "no_std")]
+use num_traits::float::Float;
 
 /// Potential errors raised during operations
 #[derive(Copy, Clone, Debug)]
@@ -234,7 +236,7 @@ impl ESKF {
     fn uncertainty3(&self, start: usize) -> Vector3<f32> {
         self.covariance
             .diagonal()
-            .fixed_slice::<3, 1>(start, 0)
+            .fixed_view_mut::<3, 1>(start, 0)
             .map(|var| var.sqrt())
     }
 
@@ -277,37 +279,37 @@ impl ESKF {
         let ident_delta = Matrix3::<f32>::identity() * delta_t;
         let mut error_jacobian = OMatrix::<f32, U18, U18>::identity();
         error_jacobian
-            .fixed_slice_mut::<3, 3>(0, 3)
+            .fixed_view_mut::<3, 3>(0, 3)
             .copy_from(&ident_delta);
         error_jacobian
-            .fixed_slice_mut::<3, 3>(3, 6)
+            .fixed_view_mut::<3, 3>(3, 6)
             .copy_from(&(-orient_mat * skew(&(acceleration - self.accel_bias)) * delta_t));
         error_jacobian
-            .fixed_slice_mut::<3, 3>(3, 9)
+            .fixed_view_mut::<3, 3>(3, 9)
             .copy_from(&(-orient_mat * delta_t));
         error_jacobian
-            .fixed_slice_mut::<3, 3>(3, 15)
+            .fixed_view_mut::<3, 3>(3, 15)
             .copy_from(&ident_delta);
         error_jacobian
-            .fixed_slice_mut::<3, 3>(6, 6)
+            .fixed_view_mut::<3, 3>(6, 6)
             .copy_from(&norm_rot.to_rotation_matrix().into_inner().transpose());
         error_jacobian
-            .fixed_slice_mut::<3, 3>(6, 12)
+            .fixed_view_mut::<3, 3>(6, 12)
             .copy_from(&-ident_delta);
         self.covariance = error_jacobian * self.covariance * error_jacobian.transpose();
         // Add noise variance
         let mut diagonal = self.covariance.diagonal();
         diagonal
-            .fixed_slice_mut::<3, 1>(3, 0)
+            .fixed_view_mut::<3, 1>(3, 0)
             .add_assign(self.var_acc * delta_t.powi(2));
         diagonal
-            .fixed_slice_mut::<3, 1>(6, 0)
+            .fixed_view_mut::<3, 1>(6, 0)
             .add_assign(self.var_rot * delta_t.powi(2));
         diagonal
-            .fixed_slice_mut::<3, 1>(9, 0)
+            .fixed_view_mut::<3, 1>(9, 0)
             .add_assign(self.var_acc_bias * delta_t);
         diagonal
-            .fixed_slice_mut::<3, 1>(12, 0)
+            .fixed_view_mut::<3, 1>(12, 0)
             .add_assign(self.var_rot_bias * delta_t);
         self.covariance.set_diagonal(&diagonal);
     }
@@ -352,20 +354,20 @@ impl ESKF {
                 (OMatrix::<f32, U18, U18>::identity() - &kalman_gain * &jacobian) * self.covariance;
         }
         // Inject error state into nominal
-        self.position += error_state.fixed_slice::<3, 1>(0, 0);
-        self.velocity += error_state.fixed_slice::<3, 1>(3, 0);
-        self.orientation *= UnitQuaternion::from_scaled_axis(error_state.fixed_slice::<3, 1>(6, 0));
-        self.accel_bias += error_state.fixed_slice::<3, 1>(9, 0);
-        self.rot_bias += error_state.fixed_slice::<3, 1>(12, 0);
-        self.gravity += error_state.fixed_slice::<3, 1>(15, 0);
+        self.position += error_state.fixed_view::<3, 1>(0, 0);
+        self.velocity += error_state.fixed_view::<3, 1>(3, 0);
+        self.orientation *= UnitQuaternion::from_scaled_axis(error_state.fixed_view::<3, 1>(6, 0));
+        self.accel_bias += error_state.fixed_view::<3, 1>(9, 0);
+        self.rot_bias += error_state.fixed_view::<3, 1>(12, 0);
+        self.gravity += error_state.fixed_view::<3, 1>(15, 0);
         // Perform full ESKF reset
         //
         // Since the orientation error is usually relatively small this step can be skipped, but
         // the full formulation can lead to better stability of the filter
         if cfg!(feature = "full-reset") {
             let mut g = OMatrix::<f32, U18, U18>::identity();
-            g.fixed_slice_mut::<3, 3>(6, 6)
-                .sub_assign(0.5 * skew(&error_state.fixed_slice::<3, 1>(6, 0).clone_owned()));
+            g.fixed_view_mut::<3, 3>(6, 6)
+                .sub_assign(0.5 * skew(&error_state.fixed_view::<3, 1>(6, 0).clone_owned()));
             self.covariance = g * self.covariance * g.transpose();
         }
         Ok(())
@@ -384,17 +386,17 @@ impl ESKF {
         velocity_var: Matrix2<f32>,
     ) -> Result<()> {
         let mut jacobian = OMatrix::<f32, U5, U18>::zeros();
-        jacobian.fixed_slice_mut::<5, 5>(0, 0).fill_with_identity();
+        jacobian.fixed_view_mut::<5, 5>(0, 0).fill_with_identity();
 
         let mut diff = OVector::<f32, U5>::zeros();
-        diff.fixed_slice_mut::<3, 1>(0, 0)
+        diff.fixed_view_mut::<3, 1>(0, 0)
             .copy_from(&(position - self.position));
-        diff.fixed_slice_mut::<2, 1>(3, 0)
+        diff.fixed_view_mut::<2, 1>(3, 0)
             .copy_from(&(velocity - self.velocity.xy()));
 
         let mut var = OMatrix::<f32, U5, U5>::zeros();
-        var.fixed_slice_mut::<3, 3>(0, 0).copy_from(&position_var);
-        var.fixed_slice_mut::<2, 2>(3, 3).copy_from(&velocity_var);
+        var.fixed_view_mut::<3, 3>(0, 0).copy_from(&position_var);
+        var.fixed_view_mut::<2, 2>(3, 3).copy_from(&velocity_var);
 
         self.update(jacobian, diff, var)
     }
@@ -406,7 +408,7 @@ impl ESKF {
         variance: Matrix3<f32>,
     ) -> Result<()> {
         let mut jacobian = OMatrix::<f32, U3, U18>::zeros();
-        jacobian.fixed_slice_mut::<3, 3>(0, 0).fill_with_identity();
+        jacobian.fixed_view_mut::<3, 3>(0, 0).fill_with_identity();
         let diff = measurement - self.position;
         self.update(jacobian, diff, variance)
     }
@@ -414,7 +416,7 @@ impl ESKF {
     /// Update the filter with an observation of the height alone
     pub fn observe_height(&mut self, measured: f32, variance: f32) -> Result<()> {
         let mut jacobian = OMatrix::<f32, U1, U18>::zeros();
-        jacobian.fixed_slice_mut::<1, 1>(0, 2).fill_with_identity();
+        jacobian.fixed_view_mut::<1, 1>(0, 2).fill_with_identity();
         let diff = OVector::<f32, U1>::new(measured - self.position.z);
         let var = OMatrix::<f32, U1, U1>::new(variance);
         self.update(jacobian, diff, var)
@@ -432,7 +434,7 @@ impl ESKF {
         variance: Matrix3<f32>,
     ) -> Result<()> {
         let mut jacobian = OMatrix::<f32, U3, U18>::zeros();
-        jacobian.fixed_slice_mut::<3, 3>(0, 3).fill_with_identity();
+        jacobian.fixed_view_mut::<3, 3>(0, 3).fill_with_identity();
         let diff = measurement - self.velocity;
         self.update(jacobian, diff, variance)
     }
@@ -449,7 +451,7 @@ impl ESKF {
         variance: Matrix2<f32>,
     ) -> Result<()> {
         let mut jacobian = OMatrix::<f32, U2, U18>::zeros();
-        jacobian.fixed_slice_mut::<2, 2>(0, 3).fill_with_identity();
+        jacobian.fixed_view_mut::<2, 2>(0, 3).fill_with_identity();
         let diff = Vector2::new(
             measurement.x - self.velocity.x,
             measurement.y - self.velocity.y,
@@ -464,7 +466,7 @@ impl ESKF {
         variance: Matrix3<f32>,
     ) -> Result<()> {
         let mut jacobian = OMatrix::<f32, U3, U18>::zeros();
-        jacobian.fixed_slice_mut::<3, 3>(0, 6).fill_with_identity();
+        jacobian.fixed_view_mut::<3, 3>(0, 6).fill_with_identity();
         let diff = measurement * self.orientation;
         self.update(jacobian, diff.scaled_axis(), variance)
     }


### PR DESCRIPTION
The docs say this crate is `#![no_std]` compatible but this was not correct because several methods on `f32` used in this crate are defined in the standard library. This PR adds an optional dependency on the `num-traits` crate that provides `#![no_std]` alternatives of the required methods (via `libm`). The dependency is guarded behind a new `no_std` feature which also enabled the `libm` feature on `nalgebra` needed to be able to compile in `#![no_std]`. 

Adding a `no_std` feature goes against the standard practice to only have additive features but there's currently no way to only include an optional dependency when a feature is _not_ enabled. In this case I think it's fine because including the `no_std` dependencies/features doesn't actually break anything, it just adds compile time. I added a compiler error explaining that the user must choose `std` XOR `no_std` to avoid confusion.

I also updated to `nalgebra` 0.32.3.